### PR TITLE
spelling fix, as of lintian.debian.org

### DIFF
--- a/uif.8
+++ b/uif.8
@@ -78,7 +78,7 @@ you may want to convert this information into a textual configuration
 file. This options writes the parsed config back to the file specified by
 .Ar config_file.
 .It Fl d
-Clears all firewall rules immediatly.
+Clears all firewall rules immediately.
 .It Fl D Ar bind_dn
 If a special account is needed to bind to the LDAP database, the account
 dn can be specified at this point. Note: you should use this when writing

--- a/uif.conf.5
+++ b/uif.conf.5
@@ -38,7 +38,7 @@ underscores and hyphens.
 .Pp
 If two or more identifiers in one section are equal, the corresponding
 entries are merged to the first identifier. Hence, it's not possible to
-overwrite perviously defined identifiers. As a result the order of the
+overwrite previously defined identifiers. As a result the order of the
 section entries is irrelevant and it's possible to define a section more
 than once.
 .Ss include section


### PR DESCRIPTION
as seen on 
https://lintian.debian.org/full/sunweaver@debian.org.html
